### PR TITLE
Make `similar` with graded axes more generic

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockSparseArrays"
 uuid = "2c9a651f-6452-4ace-a6ac-809f4280fbb4"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.2.17"
+version = "0.2.18"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/ext/BlockSparseArraysGradedUnitRangesExt/BlockSparseArraysGradedUnitRangesExt.jl
+++ b/ext/BlockSparseArraysGradedUnitRangesExt/BlockSparseArraysGradedUnitRangesExt.jl
@@ -2,7 +2,7 @@ module BlockSparseArraysGradedUnitRangesExt
 
 using BlockSparseArrays: AnyAbstractBlockSparseArray, BlockSparseArray, blocktype
 using GradedUnitRanges: AbstractGradedUnitRange
-using TypeParameterAccessors: set_eltype, set_ndims, unwrap_array_type
+using TypeParameterAccessors: similartype, unwrap_array_type
 
 # A block spare array similar to the input (dense) array.
 # TODO: Make `BlockSparseArrays.blocksparse_similar` more general and use that,
@@ -15,9 +15,7 @@ function similar_blocksparse(
   # TODO: Probably need to unwrap the type of `a` in certain cases
   # to make a proper block type.
   return BlockSparseArray{
-    elt,
-    length(axes),
-    set_eltype(set_ndims(unwrap_array_type(blocktype(a)), length(axes)), elt),
+    elt,length(axes),similartype(unwrap_array_type(blocktype(a)), elt, axes)
   }(
     axes
   )

--- a/test/test_gradedunitrangesext.jl
+++ b/test/test_gradedunitrangesext.jl
@@ -350,6 +350,21 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
     @test b[Block(1)] == a1
     @test iszero(b[Block(2)])
     @test all(GradedUnitRanges.space_isequal.(axes(b), (r,)))
+
+    # Regression test for BitArray
+    r = gradedrange([U1(0) => 2, U1(1) => 3])
+    a1 = trues(2, 2)
+    a2 = trues(3, 3)
+    a = cat(a1, a2; dims=(1, 2))
+    b = a[r, dual(r)]
+    @test eltype(b) === Bool
+    @test b isa BlockSparseMatrix{Bool}
+    @test blockstoredlength(b) == 2
+    @test b[Block(1, 1)] == a1
+    @test iszero(b[Block(2, 1)])
+    @test iszero(b[Block(1, 2)])
+    @test b[Block(2, 2)] == a2
+    @test all(GradedUnitRanges.space_isequal.(axes(b), (r, dual(r))))
   end
 end
 end


### PR DESCRIPTION
In combination with https://github.com/ITensor/TypeParameterAccessors.jl/pull/36, this fixes a bug I was hitting using `similar` with graded axes when the input is a `BitArray`.

Todo:
- [x] Add tests.