### PR TITLE
Fix splitdims(::BlockSparseArrays)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockSparseArrays"
 uuid = "2c9a651f-6452-4ace-a6ac-809f4280fbb4"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.2.18"
+version = "0.2.19"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/ext/BlockSparseArraysTensorAlgebraExt/BlockSparseArraysTensorAlgebraExt.jl
+++ b/ext/BlockSparseArraysTensorAlgebraExt/BlockSparseArraysTensorAlgebraExt.jl
@@ -1,6 +1,6 @@
 module BlockSparseArraysTensorAlgebraExt
 using BlockArrays: AbstractBlockedUnitRange
-using GradedUnitRanges: tensor_product, gradedrange
+using GradedUnitRanges: tensor_product
 using TensorAlgebra: TensorAlgebra, FusionStyle, BlockReshapeFusion
 
 function TensorAlgebra.:⊗(a1::AbstractBlockedUnitRange, a2::AbstractBlockedUnitRange)
@@ -95,9 +95,7 @@ function TensorAlgebra.splitdims(
       return length(axis) ≤ length(axes(a, i))
     end
   blockperms = blocksortperm.(axes_prod)
-  sorted_axes = ntuple(
-    i -> gradedrange(map(b -> length(axes_prod[i][b]), blockperms[i])), ndims(a)
-  )
+  sorted_axes = map((r, I) -> only(axes(r[I])), axes_prod, blockperms)
 
   # TODO: This is doing extra copies of the blocks,
   # use `@view a[axes_prod...]` instead.


### PR DESCRIPTION
Fixes #50

Non blocksorted axes were used to index an array whose axes are blocksorted. Therefore the intermediary arrays carries invalid blocks. This is a quickfix that returns the correct result, but the code can be improved.