### PR TITLE
use `BlockedTuple` in `splitdims`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockSparseArrays"
 uuid = "2c9a651f-6452-4ace-a6ac-809f4280fbb4"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.2.19"
+version = "0.2.20"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Adapt `BlockSparseArrays` to the new `TensorAlgebra.splitdims` interface defined in https://github.com/ITensor/TensorAlgebra.jl/pull/33

The new code removes the need for `reducewhile.jl`. I commented the include but did not delete the code as we may use it somewhere else or split it to its own library.