### PR TITLE
Fix generic show for block sparse arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockSparseArrays"
 uuid = "2c9a651f-6452-4ace-a6ac-809f4280fbb4"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.2.22"
+version = "0.2.23"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/blocksparsearray/blocksparsearray.jl
+++ b/src/blocksparsearray/blocksparsearray.jl
@@ -208,31 +208,3 @@ TypeParameterAccessors.position(::Type{BlockSparseArray}, ::typeof(blocktype)) =
 function TypeParameterAccessors.position(::Type{BlockSparseArray}, ::typeof(blockstype))
   return Position(4)
 end
-
-# TODO: Make this generic to `AbstractBlockSparseVector` using
-# TypeParameterAccessors.jl, for example using:
-# `set_ndims(unspecify_type_parameters(typeof(a)), 1)`.
-function show_typeof_blocksparse(io::IO, a::BlockSparseVector)
-  print(io, "BlockSparseVector")
-  print(io, '{')
-  show(io, eltype(a))
-  print(io, ", ")
-  show(io, blocktype(a))
-  print(io, ", …")
-  print(io, '}')
-  return nothing
-end
-
-# TODO: Make this generic to `AbstractBlockSparseMatrix` using
-# TypeParameterAccessors.jl, for example using:
-# `set_ndims(unspecify_type_parameters(typeof(a)), 2)`.
-function show_typeof_blocksparse(io::IO, a::BlockSparseMatrix)
-  print(io, "BlockSparseMatrix")
-  print(io, '{')
-  show(io, eltype(a))
-  print(io, ", ")
-  show(io, blocktype(a))
-  print(io, ", …")
-  print(io, '}')
-  return nothing
-end

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -1108,34 +1108,27 @@ arrayts = (Array, JLArray)
     arrayt_elt = arrayt{elt,3}
 
     a = BlockSparseVector{elt,arrayt{elt,1}}([2, 2])
+    res = sprint(summary, a)
+    ref_vec(elt, arrayt, prefix="") =
+      "2-blocked 4-element $(prefix)BlockSparseVector{$(elt), $(arrayt), …, …}"
     # Either option is possible depending on namespacing.
-    @test (
-      sprint(summary, a) ==
-      "2-blocked 4-element BlockSparseVector{$(elt), $(vectort_elt), …}"
-    ) || (
-      sprint(summary, a) ==
-      "2-blocked 4-element BlockSparseArrays.BlockSparseVector{$(elt), $(vectort_elt), …}"
-    )
+    @test (res == ref_vec(elt, vectort_elt)) ||
+      (res == ref_vec(elt, vectort_elt, "BlockSparseArrays."))
 
     a = BlockSparseMatrix{elt,arrayt{elt,2}}([2, 2], [2, 2])
+    res = sprint(summary, a)
+    ref_mat(elt, arrayt, prefix="") =
+      "2×2-blocked 4×4 $(prefix)BlockSparseMatrix{$(elt), $(arrayt), …, …}"
     # Either option is possible depending on namespacing.
-    @test (
-      sprint(summary, a) == "2×2-blocked 4×4 BlockSparseMatrix{$(elt), $(matrixt_elt), …}"
-    ) || (
-      sprint(summary, a) ==
-      "2×2-blocked 4×4 BlockSparseArrays.BlockSparseMatrix{$(elt), $(matrixt_elt), …}"
-    )
+    @test (res == ref_mat(elt, matrixt_elt)) ||
+      (res == ref_mat(elt, matrixt_elt, "BlockSparseArrays."))
 
     a = BlockSparseArray{elt,3,arrayt{elt,3}}([2, 2], [2, 2], [2, 2])
-
-    # Either option is possible depending on namespacing.
-    @test (
-      sprint(summary, a) ==
-      "2×2×2-blocked 4×4×4 BlockSparseArray{$(elt), 3, $(arrayt_elt), …}"
-    ) || (
-      sprint(summary, a) ==
-      "2×2×2-blocked 4×4×4 BlockSparseArrays.BlockSparseArray{$(elt), 3, $(arrayt_elt), …}"
-    )
+    res = sprint(summary, a)
+    ref_arr(elt, arrayt, prefix="") =
+      "2×2×2-blocked 4×4×4 BlockSparseArray{$(elt), 3, $(arrayt), …, …}"
+    @test (res == ref_arr(elt, arrayt_elt)) ||
+      (res == ref_arr(elt, arrayt_elt, "BlockSparseArrays."))
 
     if elt === Float64
       # Not testing other element types since they change the

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -1109,24 +1109,27 @@ arrayts = (Array, JLArray)
 
     a = BlockSparseVector{elt,arrayt{elt,1}}([2, 2])
     res = sprint(summary, a)
-    ref_vec(elt, arrayt, prefix="") =
-      "2-blocked 4-element $(prefix)BlockSparseVector{$(elt), $(arrayt), …, …}"
+    function ref_vec(elt, arrayt, prefix="")
+      return "2-blocked 4-element $(prefix)BlockSparseVector{$(elt), $(arrayt), …, …}"
+    end
     # Either option is possible depending on namespacing.
     @test (res == ref_vec(elt, vectort_elt)) ||
       (res == ref_vec(elt, vectort_elt, "BlockSparseArrays."))
 
     a = BlockSparseMatrix{elt,arrayt{elt,2}}([2, 2], [2, 2])
     res = sprint(summary, a)
-    ref_mat(elt, arrayt, prefix="") =
-      "2×2-blocked 4×4 $(prefix)BlockSparseMatrix{$(elt), $(arrayt), …, …}"
+    function ref_mat(elt, arrayt, prefix="")
+      return "2×2-blocked 4×4 $(prefix)BlockSparseMatrix{$(elt), $(arrayt), …, …}"
+    end
     # Either option is possible depending on namespacing.
     @test (res == ref_mat(elt, matrixt_elt)) ||
       (res == ref_mat(elt, matrixt_elt, "BlockSparseArrays."))
 
     a = BlockSparseArray{elt,3,arrayt{elt,3}}([2, 2], [2, 2], [2, 2])
     res = sprint(summary, a)
-    ref_arr(elt, arrayt, prefix="") =
-      "2×2×2-blocked 4×4×4 BlockSparseArray{$(elt), 3, $(arrayt), …, …}"
+    function ref_arr(elt, arrayt, prefix="")
+      return "2×2×2-blocked 4×4×4 $(prefix)BlockSparseArray{$(elt), 3, $(arrayt), …, …}"
+    end
     @test (res == ref_arr(elt, arrayt_elt)) ||
       (res == ref_arr(elt, arrayt_elt, "BlockSparseArrays."))
 


### PR DESCRIPTION
Fixes #63, using the same code pattern that was used in https://github.com/ITensor/NamedDimsArrays.jl/pull/48.

The show methods also have to be updated to reflect the changes @lkdvos made in https://github.com/ITensor/SparseArraysBase.jl/pull/31, but this is orthogonal to that issue since this PR is only about how the types are printed, not how the unstored values are printed.