### PR TITLE
`pre-commit autoupdate`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v5.0.0
   hooks:
   - id: check-merge-conflict
   - id: check-toml
@@ -9,6 +9,6 @@ repos:
     exclude_types: [markdown]  # incompatible with Literate.jl
 
 - repo: "https://github.com/domluna/JuliaFormatter.jl"
-  rev: v1.0.62  
+  rev: v2.1.0  
   hooks:
   - id: "julia-formatter"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,13 +2,10 @@ using BlockSparseArrays: BlockSparseArrays
 using Documenter: Documenter, DocMeta, deploydocs, makedocs
 
 DocMeta.setdocmeta!(
-  BlockSparseArrays,
-  :DocTestSetup,
-  quote
+  BlockSparseArrays, :DocTestSetup, quote
     using BlockSparseArrays
     using LinearAlgebra: Diagonal
-  end;
-  recursive=true,
+  end; recursive=true
 )
 
 include("make_index.jl")

--- a/src/blocksparsearrayinterface/blocksparsearrayinterface.jl
+++ b/src/blocksparsearrayinterface/blocksparsearrayinterface.jl
@@ -97,8 +97,9 @@ end
 
 struct BlockSparseArrayInterface <: AbstractBlockSparseArrayInterface end
 
-@interface ::AbstractBlockSparseArrayInterface BlockArrays.blocks(a::AbstractArray) =
-  error("Not implemented")
+@interface ::AbstractBlockSparseArrayInterface BlockArrays.blocks(a::AbstractArray) = error(
+  "Not implemented"
+)
 
 @interface ::AbstractBlockSparseArrayInterface function SparseArraysBase.isstored(
   a::AbstractArray{<:Any,N}, I::Vararg{Int,N}
@@ -336,10 +337,12 @@ end
 reverse_index(index) = reverse(index)
 reverse_index(index::CartesianIndex) = CartesianIndex(reverse(Tuple(index)))
 
-@interface ::AbstractBlockSparseArrayInterface BlockArrays.blocks(a::Transpose) =
-  transpose(blocks(parent(a)))
-@interface ::AbstractBlockSparseArrayInterface BlockArrays.blocks(a::Adjoint) =
-  adjoint(blocks(parent(a)))
+@interface ::AbstractBlockSparseArrayInterface BlockArrays.blocks(a::Transpose) = transpose(
+  blocks(parent(a))
+)
+@interface ::AbstractBlockSparseArrayInterface BlockArrays.blocks(a::Adjoint) = adjoint(
+  blocks(parent(a))
+)
 
 # Represents the array of arrays of a `SubArray`
 # wrapping a block spare array, i.e. `blocks(array)` where `a` is a `SubArray`.

--- a/src/factorizations/svd.jl
+++ b/src/factorizations/svd.jl
@@ -197,8 +197,9 @@ julia> Uonly == U
 true
 ```
 """
-svd(A; kwargs...) =
+function svd(A; kwargs...)
   SVD(svd!(eigencopy_oftype(A, LinearAlgebra.eigtype(eltype(A))); kwargs...))
+end
 
 LinearAlgebra.svdvals(usv::SVD{<:Any,T}) where {T} = (usv.S)::AbstractVector{T}
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,11 +14,13 @@ const GROUP = uppercase(
 )
 
 "match files of the form `test_*.jl`, but exclude `*setup*.jl`"
-istestfile(fn) =
+function istestfile(fn)
   endswith(fn, ".jl") && startswith(basename(fn), "test_") && !contains(fn, "setup")
+end
 "match files of the form `*.jl`, but exclude `*_notest.jl` and `*setup*.jl`"
-isexamplefile(fn) =
+function isexamplefile(fn)
   endswith(fn, ".jl") && !endswith(fn, "_notest.jl") && !contains(fn, "setup")
+end
 
 @time begin
   # tests in groups based on folder structure

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -242,11 +242,11 @@ arrayts = (Array, JLArray)
       @test Array(a) isa Array{elt,0}
       @test Array(a) == fill(0)
       for b in (
-        (b = copy(a); @allowscalar(b[] = 2); b),
-        (b = copy(a); @allowscalar(b[CartesianIndex()] = 2); b),
-        (b = copy(a); @allowscalar(b[Block()[]] = 2); b),
+        (b=copy(a); @allowscalar(b[] = 2); b),
+        (b=copy(a); @allowscalar(b[CartesianIndex()] = 2); b),
+        (b=copy(a); @allowscalar(b[Block()[]] = 2); b),
         # Regression test for https://github.com/ITensor/BlockSparseArrays.jl/issues/27.
-        (b = copy(a); b[Block()] = dev(fill(2)); b),
+        (b=copy(a); b[Block()]=dev(fill(2)); b),
       )
         @test size(b) == ()
         @test isone(length(b))


### PR DESCRIPTION
This is a showcase for updating `pre-commit`. It also updates JuliaFormatter to `v2.1.0`, then one can apply the new formatting style with `pre-commit run --all-files`. This would be one way to applying the new formatting.

Related: https://github.com/ITensor/ITensorActions/pull/23 