### PR TITLE
[WIP] Remove `BlockIndices`

### DIFF
--- a/src/abstractblocksparsearray/map.jl
+++ b/src/abstractblocksparsearray/map.jl
@@ -22,19 +22,6 @@ function reblock(
   return @view parent(a)[map(I -> I.array, parentindices(a))...]
 end
 
-# TODO: Make this more general, independent of `AbstractBlockSparseArray`.
-function reblock(
-  a::SubArray{
-    <:Any,
-    <:Any,
-    <:AbstractBlockSparseArray,
-    <:Tuple{Vararg{BlockIndices{<:AbstractBlockVector{<:Block{1}}}}},
-  },
-)
-  # Remove the blocking.
-  return @view parent(a)[map(I -> Vector(I.blocks), parentindices(a))...]
-end
-
 function Base.map!(f, a_dest::AbstractArray, a_srcs::AnyAbstractBlockSparseArray...)
   @interface interface(a_dest, a_srcs...) map!(f, a_dest, a_srcs...)
   return a_dest

--- a/src/blocksparsearrayinterface/blocksparsearrayinterface.jl
+++ b/src/blocksparsearrayinterface/blocksparsearrayinterface.jl
@@ -149,8 +149,7 @@ end
 @interface ::AbstractBlockSparseArrayInterface function Base.to_indices(
   a, inds, I::Tuple{Vector{<:Block{1}},Vararg{Any}}
 )
-  I1 = BlockIndices(I[1], blockedunitrange_getindices(inds[1], I[1]))
-  return (I1, to_indices(a, Base.tail(inds), Base.tail(I))...)
+  return error("Not implemented.")
 end
 
 # a[mortar([Block(1)[1:2], Block(2)[1:3]]), mortar([Block(1)[1:2], Block(2)[1:3]])]
@@ -158,8 +157,7 @@ end
 @interface ::AbstractBlockSparseArrayInterface function Base.to_indices(
   a, inds, I::Tuple{BlockVector{<:BlockIndex{1},<:Vector{<:BlockIndexRange{1}}},Vararg{Any}}
 )
-  I1 = BlockIndices(I[1], blockedunitrange_getindices(inds[1], I[1]))
-  return (I1, to_indices(a, Base.tail(inds), Base.tail(I))...)
+  return error("Not implemented.")
 end
 
 # a[BlockVector([Block(2), Block(1)], [2]), BlockVector([Block(2), Block(1)], [2])]
@@ -168,8 +166,7 @@ end
 @interface ::AbstractBlockSparseArrayInterface function Base.to_indices(
   a, inds, I::Tuple{AbstractBlockVector{<:Block{1}},Vararg{Any}}
 )
-  I1 = BlockIndices(I[1], blockedunitrange_getindices(inds[1], I[1]))
-  return (I1, to_indices(a, Base.tail(inds), Base.tail(I))...)
+  return error("Not implemented.")
 end
 
 # TODO: Need to implement this!
@@ -424,14 +421,7 @@ function SparseArraysBase.getunstoredindex(
 end
 
 to_blocks_indices(I::BlockSlice{<:BlockRange{1}}) = Int.(I.block)
-to_blocks_indices(I::BlockIndices{<:Vector{<:Block{1}}}) = Int.(I.blocks)
 to_blocks_indices(I::Base.Slice{<:BlockedOneTo}) = Base.OneTo(blocklength(I.indices))
-
-@interface ::AbstractBlockSparseArrayInterface function BlockArrays.blocks(
-  a::SubArray{<:Any,<:Any,<:Any,<:Tuple{Vararg{BlockSliceCollection}}}
-)
-  return @view blocks(parent(a))[map(to_blocks_indices, parentindices(a))...]
-end
 
 using BlockArrays: BlocksView
 SparseArraysBase.storedlength(a::BlocksView) = length(a)


### PR DESCRIPTION
The goal here is to remove `BlockIndices`, which was introduced as a more general version of `BlockArrays.BlockSlice`. `BlockArrays.BlockSlice` has since been improved so hopefully it covers the cases we need now.