### PR TITLE
[Fix] Stackoverflow in `BlockSparseArray` constructor with wrong number of axes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockSparseArrays"
 uuid = "2c9a651f-6452-4ace-a6ac-809f4280fbb4"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.4.5"
+version = "0.4.6"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/blocksparsearray/blocksparsearray.jl
+++ b/src/blocksparsearray/blocksparsearray.jl
@@ -157,6 +157,8 @@ function BlockSparseArray{T,N,A}(
   ::UndefInitializer,
   dims::Tuple{AbstractVector{<:Integer},Vararg{AbstractVector{<:Integer}}},
 ) where {T,N,A<:AbstractArray{T,N}}
+  length(dims) == N ||
+    throw(ArgumentError("Length of dims doesn't match number of dimensions."))
   return BlockSparseArray{T,N,A}(undef, blockedrange.(dims))
 end
 

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -97,6 +97,7 @@ arrayts = (Array, JLArray)
         @test iszero(blockstoredlength(a))
         @test iszero(storedlength(a))
       end
+      T != BlockSparseArray{elt} && @test_throws ArgumentError T(undef, bs[1:1])
     end
 
     # BlockSparseVector


### PR DESCRIPTION
Fixes #108 

```julia
using BlockSparseArrays
a = BlockSparseArray{Float64,2,Matrix{Float64}}(undef, ([2, 2], [2, 2])) # works
a = BlockSparseArray{Float64,2,Matrix{Float64}}(undef, ([2, 2],)) # should error - instead hangs indefinitely
```

By explicitly checking the length and throwing an error.
The alternative would be to simply restrict that constructor to only take length `N` tuples, which would throw a `MethodError` instead.