### PR TITLE
More specific interfaces

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockSparseArrays"
 uuid = "2c9a651f-6452-4ace-a6ac-809f4280fbb4"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.7.7"
+version = "0.7.8"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/BlockArraysExtensions/BlockArraysExtensions.jl
+++ b/src/BlockArraysExtensions/BlockArraysExtensions.jl
@@ -111,7 +111,7 @@ Base.view(S::BlockIndices, i) = S[i]
 # @view b[Block(1, 1)[1:2, 2:2]]
 # ```
 # This is similar to the definition:
-# @interface BlockSparseArrayInterface() to_indices(a, inds, I::Tuple{UnitRange{<:Integer},Vararg{Any}})
+# @interface interface(a) to_indices(a, inds, I::Tuple{UnitRange{<:Integer},Vararg{Any}})
 function Base.getindex(
   a::NonBlockedVector{<:Integer,<:BlockIndices}, I::UnitRange{<:Integer}
 )

--- a/src/abstractblocksparsearray/views.jl
+++ b/src/abstractblocksparsearray/views.jl
@@ -39,7 +39,7 @@ function Base.view(
   },
   I::Block{N},
 ) where {N}
-  return @interface BlockSparseArrayInterface() view(a, I)
+  return @interface interface(a) view(a, I)
 end
 function Base.view(
   a::SubArray{
@@ -47,13 +47,13 @@ function Base.view(
   },
   I::Vararg{Block{1},N},
 ) where {N}
-  return @interface BlockSparseArrayInterface() view(a, I...)
+  return @interface interface(a) view(a, I...)
 end
 function Base.view(
   V::SubArray{<:Any,1,<:AnyAbstractBlockSparseArray,<:Tuple{BlockSlice{<:BlockRange{1}}}},
   I::Block{1},
 )
-  return @interface BlockSparseArrayInterface() view(a, I)
+  return @interface interface(a) view(a, I)
 end
 
 # Specialized code for getting the view of a block.
@@ -63,7 +63,7 @@ function BlockArrays.viewblock(
   return viewblock(a, Tuple(block)...)
 end
 
-# TODO: Define `@interface BlockSparseArrayInterface() viewblock`.
+# TODO: Define `@interface interface(a) viewblock`.
 function BlockArrays.viewblock(
   a::AbstractBlockSparseArray{<:Any,N}, block::Vararg{Block{1},N}
 ) where {N}
@@ -192,9 +192,9 @@ end
 
 # XXX: TODO: Distinguish if a sub-view of the block needs to be taken!
 # Define a new `SubBlockSlice` which is used in:
-# `@interface BlockSparseArrayInterface() to_indices(a, inds, I::Tuple{UnitRange{<:Integer},Vararg{Any}})`
+# `@interface interface(a) to_indices(a, inds, I::Tuple{UnitRange{<:Integer},Vararg{Any}})`
 # in `blocksparsearrayinterface/blocksparsearrayinterface.jl`.
-# TODO: Define `@interface BlockSparseArrayInterface() viewblock`.
+# TODO: Define `@interface interface(a) viewblock`.
 function BlockArrays.viewblock(
   a::SubArray{T,N,<:AbstractBlockSparseArray{T,N},<:Tuple{Vararg{BlockSliceCollection,N}}},
   block::Vararg{Block{1},N},
@@ -248,7 +248,7 @@ function BlockArrays.viewblock(
   return @view parent(a)[brs...]
 end
 
-# TODO: Define `@interface BlockSparseArrayInterface() viewblock`.
+# TODO: Define `@interface interface() viewblock`.
 function BlockArrays.viewblock(
   a::SubArray{
     T,
@@ -295,7 +295,7 @@ end
 blockedslice_blocks(x::BlockSlice) = x.block
 blockedslice_blocks(x::BlockIndices) = x.blocks
 
-# TODO: Define `@interface BlockSparseArrayInterface() viewblock`.
+# TODO: Define `@interface interface(a) viewblock`.
 function BlockArrays.viewblock(
   a::SubArray{
     T,N,<:AbstractBlockSparseArray{T,N},<:Tuple{Vararg{SubBlockSliceCollection,N}}
@@ -311,7 +311,7 @@ function BlockArrays.viewblock(
   end
   return @view parent(a)[brs...]
 end
-# TODO: Define `@interface BlockSparseArrayInterface() viewblock`.
+# TODO: Define `@interface interface(a) viewblock`.
 function BlockArrays.viewblock(
   a::SubArray{
     T,N,<:AbstractBlockSparseArray{T,N},<:Tuple{Vararg{SubBlockSliceCollection,N}}

--- a/src/abstractblocksparsearray/wrappedabstractblocksparsearray.jl
+++ b/src/abstractblocksparsearray/wrappedabstractblocksparsearray.jl
@@ -37,27 +37,27 @@ end
 function Base.to_indices(
   a::AnyAbstractBlockSparseArray, inds, I::Tuple{UnitRange{<:Integer},Vararg{Any}}
 )
-  return @interface BlockSparseArrayInterface() to_indices(a, inds, I)
+  return @interface interface(a) to_indices(a, inds, I)
 end
 
 function Base.to_indices(
   a::AnyAbstractBlockSparseArray, inds, I::Tuple{AbstractArray{Bool},Vararg{Any}}
 )
-  return @interface BlockSparseArrayInterface() to_indices(a, inds, I)
+  return @interface interface(a) to_indices(a, inds, I)
 end
 # Fix ambiguity error with Base for logical indexing in Julia 1.10.
 # TODO: Delete this once we drop support for Julia 1.10.
 function Base.to_indices(
   a::AnyAbstractBlockSparseArray, inds, I::Union{Tuple{BitArray{N}},Tuple{Array{Bool,N}}}
 ) where {N}
-  return @interface BlockSparseArrayInterface() to_indices(a, inds, I)
+  return @interface interface(a) to_indices(a, inds, I)
 end
 
 # a[[Block(2), Block(1)], [Block(2), Block(1)]]
 function Base.to_indices(
   a::AnyAbstractBlockSparseArray, inds, I::Tuple{Vector{<:Block{1}},Vararg{Any}}
 )
-  return @interface BlockSparseArrayInterface() to_indices(a, inds, I)
+  return @interface interface(a) to_indices(a, inds, I)
 end
 
 # a[BlockVector([Block(2), Block(1)], [2]), BlockVector([Block(2), Block(1)], [2])]
@@ -67,7 +67,7 @@ function Base.to_indices(
   inds,
   I::Tuple{AbstractBlockVector{<:Block{1}},Vararg{Any}},
 )
-  return @interface BlockSparseArrayInterface() to_indices(a, inds, I)
+  return @interface interface(a) to_indices(a, inds, I)
 end
 
 # a[mortar([Block(1)[1:2], Block(2)[1:3]])]
@@ -76,7 +76,7 @@ function Base.to_indices(
   inds,
   I::Tuple{BlockVector{<:BlockIndex{1},<:Vector{<:BlockIndexRange{1}}},Vararg{Any}},
 )
-  return @interface BlockSparseArrayInterface() to_indices(a, inds, I)
+  return @interface interface(a) to_indices(a, inds, I)
 end
 
 # a[[Block(1)[1:2], Block(2)[1:2]], [Block(1)[1:2], Block(2)[1:2]]]
@@ -88,7 +88,7 @@ end
 
 # BlockArrays `AbstractBlockArray` interface
 function BlockArrays.blocks(a::AnyAbstractBlockSparseArray)
-  @interface BlockSparseArrayInterface() blocks(a)
+  @interface interface(a) blocks(a)
 end
 
 # Fix ambiguity error with `BlockArrays`
@@ -96,7 +96,7 @@ using BlockArrays: BlockSlice
 function BlockArrays.blocks(
   a::SubArray{<:Any,<:Any,<:AbstractBlockSparseArray,<:Tuple{Vararg{BlockSlice}}}
 )
-  return @interface BlockSparseArrayInterface() blocks(a)
+  return @interface interface(a) blocks(a)
 end
 
 using TypeParameterAccessors: parenttype
@@ -129,7 +129,7 @@ function Base.getindex(a::AnyAbstractBlockSparseArray{<:Any,0})
   return ArrayLayouts.layout_getindex(a)
 end
 
-# TODO: Define `@interface BlockSparseArrayInterface() isassigned`.
+# TODO: Define `@interface interface(a) isassigned`.
 function Base.isassigned(
   a::AnyAbstractBlockSparseArray{<:Any,N}, index::Vararg{Block{1},N}
 ) where {N}
@@ -145,7 +145,7 @@ function Base.isassigned(a::AnyAbstractBlockSparseArray{<:Any,N}, index::Block{N
   return isassigned(a, Tuple(index)...)
 end
 
-# TODO: Define `@interface BlockSparseArrayInterface() isassigned`.
+# TODO: Define `@interface interface(a) isassigned`.
 function Base.isassigned(
   a::AnyAbstractBlockSparseArray{<:Any,N}, index::Vararg{BlockIndex{1},N}
 ) where {N}
@@ -157,13 +157,13 @@ function Base.setindex!(
   a::AnyAbstractBlockSparseArray{<:Any,N}, value, I::BlockIndex{N}
 ) where {N}
   # TODO: Use `@interface interface(a) setindex!(...)`.
-  @interface BlockSparseArrayInterface() setindex!(a, value, I)
+  @interface interface(a) setindex!(a, value, I)
   return a
 end
 # Fixes ambiguity error with BlockArrays.jl
 function Base.setindex!(a::AnyAbstractBlockSparseArray{<:Any,1}, value, I::BlockIndex{1})
   # TODO: Use `@interface interface(a) setindex!(...)`.
-  @interface BlockSparseArrayInterface() setindex!(a, value, I)
+  @interface interface(a) setindex!(a, value, I)
   return a
 end
 
@@ -269,29 +269,29 @@ end
 end
 
 # Needed by `BlockArrays` matrix multiplication interface
-# TODO: Define a `@interface BlockSparseArrayInterface() similar` function.
+# TODO: Define a `@interface interface(a) similar` function.
 function Base.similar(
   arraytype::Type{<:AnyAbstractBlockSparseArray},
   elt::Type,
   axes::Tuple{Vararg{AbstractUnitRange{<:Integer}}},
 )
-  return @interface BlockSparseArrayInterface() similar(arraytype, elt, axes)
+  return @interface interface(arraytype) similar(arraytype, elt, axes)
 end
 
-# TODO: Define a `@interface BlockSparseArrayInterface() similar` function.
+# TODO: Define a `@interface interface(a) similar` function.
 function Base.similar(
   a::AnyAbstractBlockSparseArray,
   elt::Type,
   axes::Tuple{Vararg{AbstractUnitRange{<:Integer}}},
 )
   # TODO: Use `@interface interface(a) similar(...)`.
-  return @interface BlockSparseArrayInterface() similar(a, elt, axes)
+  return @interface interface(a) similar(a, elt, axes)
 end
 
 # Fixes ambiguity error.
 function Base.similar(a::AnyAbstractBlockSparseArray, elt::Type, axes::Tuple{})
   # TODO: Use `@interface interface(a) similar(...)`.
-  return @interface BlockSparseArrayInterface() similar(a, elt, axes)
+  return @interface interface(a) similar(a, elt, axes)
 end
 
 # Fixes ambiguity error with `BlockArrays`.
@@ -303,7 +303,7 @@ function Base.similar(
   },
 )
   # TODO: Use `@interface interface(a) similar(...)`.
-  return @interface BlockSparseArrayInterface() similar(a, elt, axes)
+  return @interface interface(a) similar(a, elt, axes)
 end
 
 # Fixes ambiguity error with `OffsetArrays`.
@@ -313,7 +313,7 @@ function Base.similar(
   axes::Tuple{AbstractUnitRange{<:Integer},Vararg{AbstractUnitRange{<:Integer}}},
 )
   # TODO: Use `@interface interface(a) similar(...)`.
-  return @interface BlockSparseArrayInterface() similar(a, elt, axes)
+  return @interface interface(a) similar(a, elt, axes)
 end
 
 # Fixes ambiguity error with `BlockArrays`.
@@ -323,7 +323,7 @@ function Base.similar(
   axes::Tuple{AbstractBlockedUnitRange{<:Integer},Vararg{AbstractUnitRange{<:Integer}}},
 )
   # TODO: Use `@interface interface(a) similar(...)`.
-  return @interface BlockSparseArrayInterface() similar(a, elt, axes)
+  return @interface interface(a) similar(a, elt, axes)
 end
 
 # Fixes ambiguity errors with BlockArrays.
@@ -337,7 +337,7 @@ function Base.similar(
   },
 )
   # TODO: Use `@interface interface(a) similar(...)`.
-  return @interface BlockSparseArrayInterface() similar(a, elt, axes)
+  return @interface interface(a) similar(a, elt, axes)
 end
 
 # Fixes ambiguity error with `StaticArrays`.
@@ -345,7 +345,7 @@ function Base.similar(
   a::AnyAbstractBlockSparseArray, elt::Type, axes::Tuple{Base.OneTo,Vararg{Base.OneTo}}
 )
   # TODO: Use `@interface interface(a) similar(...)`.
-  return @interface BlockSparseArrayInterface() similar(a, elt, axes)
+  return @interface interface(a) similar(a, elt, axes)
 end
 
 struct BlockType{T} end

--- a/src/blocksparsearray/blocksparsearray.jl
+++ b/src/blocksparsearray/blocksparsearray.jl
@@ -259,6 +259,12 @@ Base.axes(a::BlockSparseArray) = a.axes
 @interface ::AbstractBlockSparseArrayInterface BlockArrays.blocks(a::BlockSparseArray) =
   a.blocks
 
+function blocktype(
+  arraytype::Type{<:BlockSparseArray{T,N,A}}
+) where {T,N,A<:AbstractArray{T,N}}
+  return A
+end
+
 # TODO: Use `TypeParameterAccessors`.
 function blockstype(
   arraytype::Type{<:BlockSparseArray{T,N,A,Blocks}}


### PR DESCRIPTION
Replace uses of `BlockSparseArrayInterface()` with `interface(a)` to allow for more specialization.