### PR TITLE
Make map/broadcast a bit more customizable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockSparseArrays"
 uuid = "2c9a651f-6452-4ace-a6ac-809f4280fbb4"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.7.16"
+version = "0.7.17"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/blocksparsearrayinterface/map.jl
+++ b/src/blocksparsearrayinterface/map.jl
@@ -26,14 +26,14 @@ function viewblock_stored(a::AbstractArray{<:Any,N}, I::Block{N}) where {N}
   return viewblock_stored(a, Tuple(I)...)
 end
 
-using FillArrays: Zeros
+using FillArrays: Zeros, fillsimilar
 # Get a view of a block if it is stored, otherwise return a lazy zeros.
 function viewblock_or_zeros(a::AbstractArray{<:Any,N}, I::Vararg{Block{1},N}) where {N}
   if isstored(a, I...)
     return viewblock_stored(a, I...)
   else
     block_ax = map((ax, i) -> eachblockaxis(ax)[Int(i)], axes(a), I)
-    return Zeros{eltype(a)}(block_ax)
+    return fillsimilar(Zeros{eltype(a)}(block_ax), block_ax)
   end
 end
 function viewblock_or_zeros(a::AbstractArray{<:Any,N}, I::Block{N}) where {N}


### PR DESCRIPTION
Followup to https://github.com/ITensor/BlockSparseArrays.jl/pull/150. Make blockwise map/broadcast a bit more customizable by allowing customizing how unstored blocks get constructed. This is helpful for use cases like having blocks that are Kronecker arrays, since it is helpful to construct unstored blocks with Kronecker structures, which this PR enables by overloading `FillArrays.fillsimilar`.