### PR TITLE
Generalize BlockIndexVector

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BlockSparseArrays"
 uuid = "2c9a651f-6452-4ace-a6ac-809f4280fbb4"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.7.19"
+version = "0.7.20"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/abstractblocksparsearray/views.jl
+++ b/src/abstractblocksparsearray/views.jl
@@ -95,7 +95,7 @@ to_block(I::BlockIndexRange{1}) = Block(I)
 to_block(I::BlockIndexVector) = Block(I)
 to_block_indices(I::Block{1}) = Colon()
 to_block_indices(I::BlockIndexRange{1}) = only(I.indices)
-to_block_indices(I::BlockIndexVector) = I.indices
+to_block_indices(I::BlockIndexVector) = only(I.indices)
 
 function Base.view(
   a::AbstractBlockSparseArray{<:Any,N},


### PR DESCRIPTION
Generalize BlockIndexVector (which itself is a generalization of `BlockIndexRange` for representing a subslice of a block to non-ranges) to n-dimensions and also to non-integer indices, which is helpful for generalized indexing used in KroneckerArrays.jl.