### PR TITLE
Use type inference for blocktype instead of runtime mapreduce

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockSparseArrays"
 uuid = "2c9a651f-6452-4ace-a6ac-809f4280fbb4"
-version = "0.10.35"
+version = "0.10.36"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/blocksparsearrayinterface/blocksparsearrayinterface.jl
+++ b/src/blocksparsearrayinterface/blocksparsearrayinterface.jl
@@ -1,7 +1,7 @@
 using ArrayLayouts: ArrayLayouts
 using BlockArrays: BlockArrays, AbstractBlockVector, Block, BlockIndex, BlockRange,
-    BlockSlice, BlockVector, BlockedUnitRange, BlockedVector, block, blockcheckbounds,
-    blockisequal, blocklength, blocklengths, blocks, findblockindex
+    BlockSlice, BlockVector, BlockedUnitRange, BlockedVector, BlocksView, block,
+    blockcheckbounds, blockisequal, blocklength, blocklengths, blocks, findblockindex
 using FunctionImplementations: FunctionImplementations, permuteddims, zero!
 using LinearAlgebra: Adjoint, Transpose
 using SparseArraysBase: AbstractSparseArrayImplementationStyle, eachstoredindex,
@@ -75,12 +75,12 @@ julia> length(blocks(BlockedVector{Float64}(randn(0))))
 1
 ```
 =#
-function blocktype(a::AbstractArray)
-    if isempty(blocks(a))
-        error("`blocktype` can't be determined if `isempty(blocks(a))`.")
-    end
-    return mapreduce(typeof, promote_type, blocks(a))
+eltype_inferred(a::AbstractArray{T}) where {T} = T
+function eltype_inferred(a::BlocksView{<:Any, N}) where {N}
+    return Base.promote_op(getindex, typeof(a), ntuple(Returns(Int), Val(N))...)
 end
+
+blocktype(a::AbstractArray) = eltype_inferred(blocks(a))
 
 using BlockArrays: BlockArray
 blockstype(::Type{<:BlockArray{<:Any, <:Any, B}}) where {B} = B
@@ -526,5 +526,4 @@ function blocks_blocksparse(
     return @view blocks(parent(a))[map(to_blocks_indices, parentindices(a))...]
 end
 
-using BlockArrays: BlocksView
 SparseArraysBase.storedlength(a::BlocksView) = length(a)

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -174,9 +174,8 @@ arrayts = (Array, JLArray)
         @test (@constinferred blockstype(a)) <: BlockArrays.BlocksView{elt, 2}
         # TODO: This is difficult to determine just from type information.
         @test_broken blockstype(typeof(a)) <: BlockArrays.BlocksView{elt, 2}
-        @test (@constinferred blocktype(a)) <: SubArray{elt, 2, arrayt{elt, 2}}
-        # TODO: This is difficult to determine just from type information.
-        @test_broken blocktype(typeof(a)) <: SubArray{elt, 2, arrayt{elt, 2}}
+        @test blocktype(a) <: AbstractMatrix{elt}
+        @test_broken blocktype(typeof(a)) <: AbstractMatrix{elt}
 
         # sparsemortar
         for ax in (


### PR DESCRIPTION
## Summary
- Replace runtime `mapreduce(typeof, promote_type, blocks(a))` in `blocktype(::AbstractArray)` with `eltype_inferred(blocks(a))`, which uses static type parameters by default.
- Add `eltype_inferred(::BlocksView)` specialization using `promote_op(getindex, ...)` for a tighter result than the abstract `eltype`.
- Relax the `BlockedArray` `blocktype` test from `@constinferred ... <: SubArray` to `blocktype(a) <: AbstractMatrix{elt}`, since the inferred type depends on the parent array and may be abstract or a Union.

The previous implementation relied on aggressive const-propagation that broke on Julia v1.12.6 x86_64 (JuliaLang/julia#57582 changed inference behavior). It also errored on empty arrays.

## Test plan
- [x] `test_basics.jl` passes locally (fresh subprocess, all 6 arraytype/eltype combos)
- [ ] CI passes on Julia LTS and Julia 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)