### PR TITLE
Make test_abstract_blocktype work with MatrixAlgebraKit 0.6.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockSparseArrays"
 uuid = "2c9a651f-6452-4ace-a6ac-809f4280fbb4"
-version = "0.10.39"
+version = "0.10.40"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/test/test_abstract_blocktype.jl
+++ b/test/test_abstract_blocktype.jl
@@ -15,7 +15,6 @@ arrayts = (Array, JLArray)
 @testset "Abstract block type (arraytype=$arrayt, eltype=$elt)" for arrayt in arrayts,
         elt in elts
 
-    rng = StableRNG(1)
     dev = adapt(arrayt)
 
     a = BlockSparseMatrix{elt, AbstractMatrix{elt}}(undef, [2, 3], [2, 3])
@@ -23,6 +22,7 @@ arrayts = (Array, JLArray)
     @test iszero(storedlength(a))
     @test iszero(blockstoredlength(a))
 
+    rng = StableRNG(1234)
     a = BlockSparseMatrix{elt, AbstractMatrix{elt}}(undef, [2, 3], [2, 3])
     a[Block(1, 1)] = dev(randn(rng, elt, 2, 2))
     @test !iszero(a[Block(1, 1)])
@@ -34,6 +34,7 @@ arrayts = (Array, JLArray)
     @test iszero(a[Block(1, 2)])
     @test a[Block(1, 2)] isa Matrix{elt}
 
+    rng = StableRNG(1234)
     a = BlockSparseMatrix{elt, AbstractMatrix{elt}}(undef, [2, 3], [2, 3])
     a[Block(1, 1)] = dev(randn(rng, elt, 2, 2))
     a′ = BlockSparseMatrix{elt, AbstractMatrix{elt}}(undef, [2, 3], [2, 3])
@@ -55,6 +56,7 @@ arrayts = (Array, JLArray)
     @test Array(b) ≈ Array(a) * Array(a′)
     @test norm(b) ≈ 0
 
+    rng = StableRNG(1234)
     a = BlockSparseMatrix{elt, AbstractMatrix{elt}}(undef, [2, 3], [2, 3])
     a[Block(1, 1)] = dev(randn(rng, elt, 2, 2))
     for f in (eig_full, eig_trunc)
@@ -72,6 +74,7 @@ arrayts = (Array, JLArray)
         @test_broken eig_vals(a)
     end
 
+    rng = StableRNG(1234)
     a = BlockSparseMatrix{elt, AbstractMatrix{elt}}(undef, [2, 3], [2, 3])
     a[Block(1, 1)] = dev(parent(hermitianpart(randn(rng, elt, 2, 2))))
     for f in (eigh_full, eigh_trunc)
@@ -89,6 +92,7 @@ arrayts = (Array, JLArray)
         @test_broken eigh_vals(a)
     end
 
+    rng = StableRNG(1234)
     a = BlockSparseMatrix{elt, AbstractMatrix{elt}}(undef, [2, 3], [2, 3])
     a[Block(1, 1)] = dev(randn(rng, elt, 2, 2))
     for f in (left_orth, left_polar, qr_compact, qr_full)

--- a/test/test_abstract_blocktype.jl
+++ b/test/test_abstract_blocktype.jl
@@ -8,7 +8,7 @@ using MatrixAlgebraKit: eig_full, eig_trunc, eig_vals, eigh_full, eigh_trunc, ei
     right_orth, right_polar, svd_compact, svd_full, svd_trunc
 using SparseArraysBase: storedlength
 using StableRNGs: StableRNG
-using Test: @test, @test_broken, @testset
+using Test: @test, @testset
 
 elts = (Float32, Float64, ComplexF32)
 arrayts = (Array, JLArray)
@@ -60,37 +60,29 @@ arrayts = (Array, JLArray)
     a = BlockSparseMatrix{elt, AbstractMatrix{elt}}(undef, [2, 3], [2, 3])
     a[Block(1, 1)] = dev(randn(rng, elt, 2, 2))
     for f in (eig_full, eig_trunc)
-        if arrayt === Array
+        @test begin
             d, v = f(a)
-            @test a * v ≈ v * d
-        else
-            @test_broken f(a)
-        end
+            a * v ≈ v * d
+        end broken = arrayt ≢ Array
     end
-    if arrayt === Array
+    @test begin
         d = eig_vals(a)
-        @test sort(Vector(d); by = abs) ≈ sort(eig_vals(Matrix(a)); by = abs)
-    else
-        @test_broken eig_vals(a)
-    end
+        sort(Vector(d); by = abs) ≈ sort(eig_vals(Matrix(a)); by = abs)
+    end broken = arrayt ≢ Array
 
     rng = StableRNG(1234)
     a = BlockSparseMatrix{elt, AbstractMatrix{elt}}(undef, [2, 3], [2, 3])
     a[Block(1, 1)] = dev(parent(hermitianpart(randn(rng, elt, 2, 2))))
     for f in (eigh_full, eigh_trunc)
-        if arrayt === Array
+        @test begin
             d, v = f(a)
-            @test a * v ≈ v * d
-        else
-            @test_broken f(a)
-        end
+            a * v ≈ v * d
+        end broken = arrayt ≢ Array
     end
-    if arrayt === Array
+    @test begin
         d = eigh_vals(a)
-        @test sort(Vector(d); by = abs) ≈ sort(eig_vals(Matrix(a)); by = abs)
-    else
-        @test_broken eigh_vals(a)
-    end
+        sort(Vector(d); by = abs) ≈ sort(eig_vals(Matrix(a)); by = abs)
+    end broken = arrayt ≢ Array
 
     rng = StableRNG(1234)
     a = BlockSparseMatrix{elt, AbstractMatrix{elt}}(undef, [2, 3], [2, 3])
@@ -98,12 +90,8 @@ arrayts = (Array, JLArray)
     for f in (left_orth, left_polar, qr_compact, qr_full)
         u, c = f(a)
         @test u * c ≈ a
-        if arrayt ≡ Array
-            @test isisometric(u; side = :left)
-        else
-            # TODO: Fix comparison with UniformScaling on GPU.
-            @test_broken isisometric(u; side = :left)
-        end
+        # TODO: Fix comparison with UniformScaling on GPU.
+        @test isisometric(u; side = :left) broken = arrayt ≢ Array
     end
     for f in (right_orth, right_polar, lq_compact, lq_full)
         c, u = f(a)
@@ -112,24 +100,15 @@ arrayts = (Array, JLArray)
         # reproduce `a` (regression in MatrixAlgebraKit 0.6.6, tracked at
         # https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/issues/218).
         @test c * u ≈ a broken = (arrayt ≢ Array && f ∈ (right_orth, lq_compact, lq_full))
-        if arrayt ≡ Array
-            @test isisometric(u; side = :right)
-        else
-            # TODO: Fix comparison with UniformScaling on GPU.
-            @test_broken isisometric(u; side = :right)
-        end
+        # TODO: Fix comparison with UniformScaling on GPU.
+        @test isisometric(u; side = :right) broken = arrayt ≢ Array
     end
     for f in (svd_compact, svd_full, svd_trunc)
-        if arrayt ≢ Array && f ≡ svd_trunc
-            # `svd_trunc` on JLArray-backed `BlockSparseMatrix{T, AbstractMatrix{T}}`
-            # currently triggers scalar indexing on the GPU array.
-            @test begin
-                u, s, v = f(a)
-                u * s * v ≈ a
-            end broken = true
-        else
+        # `svd_trunc` on JLArray-backed `BlockSparseMatrix{T, AbstractMatrix{T}}`
+        # currently triggers scalar indexing on the GPU array.
+        @test begin
             u, s, v = f(a)
-            @test u * s * v ≈ a
-        end
+            u * s * v ≈ a
+        end broken = (arrayt ≢ Array && f ≡ svd_trunc)
     end
 end

--- a/test/test_abstract_blocktype.jl
+++ b/test/test_abstract_blocktype.jl
@@ -105,7 +105,8 @@ arrayts = (Array, JLArray)
         c, u = f(a)
         # `right_orth`, `lq_compact`, `lq_full` on JLArray-backed
         # `BlockSparseMatrix{T, AbstractMatrix{T}}` produce a `c * u` that does not
-        # reproduce `a` (regression in MatrixAlgebraKit 0.6.6).
+        # reproduce `a` (regression in MatrixAlgebraKit 0.6.6, tracked at
+        # https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/issues/218).
         @test c * u ≈ a broken = (arrayt ≢ Array && f ∈ (right_orth, lq_compact, lq_full))
         if arrayt ≡ Array
             @test isisometric(u; side = :right)

--- a/test/test_abstract_blocktype.jl
+++ b/test/test_abstract_blocktype.jl
@@ -99,10 +99,10 @@ arrayts = (Array, JLArray)
         # `BlockSparseMatrix{T, AbstractMatrix{T}}` produce a `c * u` that does not
         # reproduce `a` (regression in MatrixAlgebraKit 0.6.6; fix tracked at
         # https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/219).
-        @test c * u ≈ a broken = (
+        broken =
             arrayt ≢ Array && f ∈ (right_orth, lq_compact, lq_full) &&
-                pkgversion(MatrixAlgebraKit) < v"0.6.7"
-        )
+            pkgversion(MatrixAlgebraKit) < v"0.6.7"
+        @test c * u ≈ a broken = broken
         # TODO: Fix comparison with UniformScaling on GPU.
         @test isisometric(u; side = :right) broken = arrayt ≢ Array
     end

--- a/test/test_abstract_blocktype.jl
+++ b/test/test_abstract_blocktype.jl
@@ -7,6 +7,7 @@ using MatrixAlgebraKit: eig_full, eig_trunc, eig_vals, eigh_full, eigh_trunc, ei
     isisometric, left_orth, left_polar, lq_compact, lq_full, qr_compact, qr_full,
     right_orth, right_polar, svd_compact, svd_full, svd_trunc
 using SparseArraysBase: storedlength
+using StableRNGs: StableRNG
 using Test: @test, @test_broken, @testset
 
 elts = (Float32, Float64, ComplexF32)
@@ -14,6 +15,7 @@ arrayts = (Array, JLArray)
 @testset "Abstract block type (arraytype=$arrayt, eltype=$elt)" for arrayt in arrayts,
         elt in elts
 
+    rng = StableRNG(1)
     dev = adapt(arrayt)
 
     a = BlockSparseMatrix{elt, AbstractMatrix{elt}}(undef, [2, 3], [2, 3])
@@ -22,7 +24,7 @@ arrayts = (Array, JLArray)
     @test iszero(blockstoredlength(a))
 
     a = BlockSparseMatrix{elt, AbstractMatrix{elt}}(undef, [2, 3], [2, 3])
-    a[Block(1, 1)] = dev(randn(elt, 2, 2))
+    a[Block(1, 1)] = dev(randn(rng, elt, 2, 2))
     @test !iszero(a[Block(1, 1)])
     @test a[Block(1, 1)] isa arrayt{elt, 2}
     @test iszero(a[Block(2, 2)])
@@ -33,9 +35,9 @@ arrayts = (Array, JLArray)
     @test a[Block(1, 2)] isa Matrix{elt}
 
     a = BlockSparseMatrix{elt, AbstractMatrix{elt}}(undef, [2, 3], [2, 3])
-    a[Block(1, 1)] = dev(randn(elt, 2, 2))
+    a[Block(1, 1)] = dev(randn(rng, elt, 2, 2))
     a′ = BlockSparseMatrix{elt, AbstractMatrix{elt}}(undef, [2, 3], [2, 3])
-    a′[Block(2, 2)] = dev(randn(elt, 3, 3))
+    a′[Block(2, 2)] = dev(randn(rng, elt, 3, 3))
 
     b = copy(a)
     @test Array(b) ≈ Array(a)
@@ -54,7 +56,7 @@ arrayts = (Array, JLArray)
     @test norm(b) ≈ 0
 
     a = BlockSparseMatrix{elt, AbstractMatrix{elt}}(undef, [2, 3], [2, 3])
-    a[Block(1, 1)] = dev(randn(elt, 2, 2))
+    a[Block(1, 1)] = dev(randn(rng, elt, 2, 2))
     for f in (eig_full, eig_trunc)
         if arrayt === Array
             d, v = f(a)
@@ -71,7 +73,7 @@ arrayts = (Array, JLArray)
     end
 
     a = BlockSparseMatrix{elt, AbstractMatrix{elt}}(undef, [2, 3], [2, 3])
-    a[Block(1, 1)] = dev(parent(hermitianpart(randn(elt, 2, 2))))
+    a[Block(1, 1)] = dev(parent(hermitianpart(randn(rng, elt, 2, 2))))
     for f in (eigh_full, eigh_trunc)
         if arrayt === Array
             d, v = f(a)
@@ -88,7 +90,7 @@ arrayts = (Array, JLArray)
     end
 
     a = BlockSparseMatrix{elt, AbstractMatrix{elt}}(undef, [2, 3], [2, 3])
-    a[Block(1, 1)] = dev(randn(elt, 2, 2))
+    a[Block(1, 1)] = dev(randn(rng, elt, 2, 2))
     for f in (left_orth, left_polar, qr_compact, qr_full)
         u, c = f(a)
         @test u * c ≈ a
@@ -101,7 +103,10 @@ arrayts = (Array, JLArray)
     end
     for f in (right_orth, right_polar, lq_compact, lq_full)
         c, u = f(a)
-        @test c * u ≈ a
+        # `right_orth`, `lq_compact`, `lq_full` on JLArray-backed
+        # `BlockSparseMatrix{T, AbstractMatrix{T}}` produce a `c * u` that does not
+        # reproduce `a` (regression in MatrixAlgebraKit 0.6.6).
+        @test c * u ≈ a broken = (arrayt ≢ Array && f ∈ (right_orth, lq_compact, lq_full))
         if arrayt ≡ Array
             @test isisometric(u; side = :right)
         else
@@ -110,8 +115,13 @@ arrayts = (Array, JLArray)
         end
     end
     for f in (svd_compact, svd_full, svd_trunc)
-        if arrayt ≢ Array && (f ≡ svd_full || f ≡ svd_trunc)
-            @test_broken f(a)
+        if arrayt ≢ Array && f ≡ svd_trunc
+            # `svd_trunc` on JLArray-backed `BlockSparseMatrix{T, AbstractMatrix{T}}`
+            # currently triggers scalar indexing on the GPU array.
+            @test begin
+                u, s, v = f(a)
+                u * s * v ≈ a
+            end broken = true
         else
             u, s, v = f(a)
             @test u * s * v ≈ a

--- a/test/test_abstract_blocktype.jl
+++ b/test/test_abstract_blocktype.jl
@@ -3,9 +3,9 @@ using BlockArrays: Block
 using BlockSparseArrays: BlockSparseMatrix, blockstoredlength
 using JLArrays: JLArray
 using LinearAlgebra: hermitianpart, norm
-using MatrixAlgebraKit: eig_full, eig_trunc, eig_vals, eigh_full, eigh_trunc, eigh_vals,
-    isisometric, left_orth, left_polar, lq_compact, lq_full, qr_compact, qr_full,
-    right_orth, right_polar, svd_compact, svd_full, svd_trunc
+using MatrixAlgebraKit: MatrixAlgebraKit, eig_full, eig_trunc, eig_vals, eigh_full,
+    eigh_trunc, eigh_vals, isisometric, left_orth, left_polar, lq_compact, lq_full,
+    qr_compact, qr_full, right_orth, right_polar, svd_compact, svd_full, svd_trunc
 using SparseArraysBase: storedlength
 using StableRNGs: StableRNG
 using Test: @test, @testset
@@ -97,9 +97,12 @@ arrayts = (Array, JLArray)
         c, u = f(a)
         # `right_orth`, `lq_compact`, `lq_full` on JLArray-backed
         # `BlockSparseMatrix{T, AbstractMatrix{T}}` produce a `c * u` that does not
-        # reproduce `a` (regression in MatrixAlgebraKit 0.6.6, tracked at
-        # https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/issues/218).
-        @test c * u ≈ a broken = (arrayt ≢ Array && f ∈ (right_orth, lq_compact, lq_full))
+        # reproduce `a` (regression in MatrixAlgebraKit 0.6.6; fix tracked at
+        # https://github.com/QuantumKitHub/MatrixAlgebraKit.jl/pull/219).
+        @test c * u ≈ a broken = (
+            arrayt ≢ Array && f ∈ (right_orth, lq_compact, lq_full) &&
+                pkgversion(MatrixAlgebraKit) < v"0.6.7"
+        )
         # TODO: Fix comparison with UniformScaling on GPU.
         @test isisometric(u; side = :right) broken = arrayt ≢ Array
     end

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -11,7 +11,7 @@ using JLArrays: JLArray, JLMatrix
 using LinearAlgebra: Adjoint, Transpose, dot, norm, tr
 using SparseArraysBase:
     SparseArrayDOK, SparseMatrixDOK, SparseVectorDOK, isstored, storedlength
-using Test: @inferred, @test, @test_broken, @test_throws, @testset
+using Test: @inferred, @test, @test_throws, @testset
 using TestExtras: @constinferred
 using TypeParameterAccessors: TypeParameterAccessors, Position
 include("TestBlockSparseArraysUtils.jl")
@@ -28,18 +28,18 @@ arrayts = (Array, JLArray)
         a = dev(BlockSparseArray{elt}(undef, [2, 3], [2, 3]))
         a[Block(1, 1)] = dev(randn(elt, 2, 2))
         a[Block(2, 2)] = dev(randn(elt, 3, 3))
-        @test_broken a[:, 4]
+        @test a[:, 4] broken = true
 
         # TODO: Fix this and turn it into a proper test.
         a = dev(BlockSparseArray{elt}(undef, [2, 3], [2, 3]))
         a[Block(1, 1)] = dev(randn(elt, 2, 2))
         a[Block(2, 2)] = dev(randn(elt, 3, 3))
         @allowscalar @test a[2:4, 4] == Array(a)[2:4, 4]
-        @test_broken a[4, 2:4]
+        @test a[4, 2:4] broken = true
 
         @test a[Block(1), :] isa BlockSparseArray{elt}
         @test adjoint(a) isa Adjoint{elt, <:BlockSparseArray}
-        @test_broken adjoint(a)[Block(1), :] isa Adjoint{elt, <:BlockSparseArray}
+        @test adjoint(a)[Block(1), :] isa Adjoint{elt, <:BlockSparseArray} broken = true
         # could also be directly a BlockSparseArray
     end
     @testset "Constructors" begin
@@ -153,10 +153,10 @@ arrayts = (Array, JLArray)
         a = arrayt(randn(elt, 2, 2))
         @test (@constinferred blockstype(a)) <: BlockArrays.BlockView{elt, 2}
         # TODO: This is difficult to determine just from type information.
-        @test_broken blockstype(typeof(a)) <: BlockArrays.BlockView{elt, 2}
+        @test blockstype(typeof(a)) <: BlockArrays.BlockView{elt, 2} broken = true
         @test (@constinferred blocktype(a)) <: arrayt{elt, 2}
         # TODO: This is difficult to determine just from type information.
-        @test_broken blocktype(typeof(a)) <: SubArray{elt, 2, arrayt{elt, 2}}
+        @test blocktype(typeof(a)) <: SubArray{elt, 2, arrayt{elt, 2}} broken = true
 
         a = BlockSparseMatrix{elt, arrayt{elt, 2}}(undef, [1, 1], [1, 1])
         @test (@constinferred blockstype(a)) <: SparseMatrixDOK{arrayt{elt, 2}}
@@ -173,9 +173,9 @@ arrayts = (Array, JLArray)
         a = BlockedArray(arrayt(randn(elt, 2, 2)), [1, 1], [1, 1])
         @test (@constinferred blockstype(a)) <: BlockArrays.BlocksView{elt, 2}
         # TODO: This is difficult to determine just from type information.
-        @test_broken blockstype(typeof(a)) <: BlockArrays.BlocksView{elt, 2}
+        @test blockstype(typeof(a)) <: BlockArrays.BlocksView{elt, 2} broken = true
         @test blocktype(a) <: AbstractMatrix{elt}
-        @test_broken blocktype(typeof(a)) <: AbstractMatrix{elt}
+        @test blocktype(typeof(a)) <: AbstractMatrix{elt} broken = true
 
         # sparsemortar
         for ax in (

--- a/test/test_genericblockindex.jl
+++ b/test/test_genericblockindex.jl
@@ -3,7 +3,7 @@ using BlockArrays: Block, BlockIndex, BlockSlice, BlockedArray, BlockedVector, b
 using BlockSparseArrays: BlockSparseArrays, BlockIndexVector, BlockIndices,
     GenericBlockIndex, blockedunitrange_getindices, blocksparsezeros, to_block,
     to_block_indices, to_blockindexrange
-using Test: @test, @test_broken, @testset
+using Test: @test, @testset
 
 # blockrange
 # checkindex

--- a/test/test_map.jl
+++ b/test/test_map.jl
@@ -7,7 +7,7 @@ using GPUArraysCore: @allowscalar
 using JLArrays: JLArray
 using SparseArraysBase: storedlength
 using StableRNGs: StableRNG
-using Test: @test, @test_broken, @test_throws, @testset
+using Test: @test, @test_throws, @testset
 
 elts = (Float32, Float64, ComplexF32)
 arrayts = (Array, JLArray)
@@ -407,12 +407,8 @@ arrayts = (Array, JLArray)
     a[Block(1, 1)] = dev(randn(elt, 2, 2))
     a[Block(2, 2)] = dev(randn(elt, 3, 3))
     I = (:, [2, 4])
-    if arrayt === Array
-        @test Array(a[I...]) == Array(a)[I...]
-    else
-        # TODO: Broken on GPU, fix this.
-        @test_broken a[I...]
-    end
+    # TODO: Broken on GPU, fix this.
+    @test Array(a[I...]) == Array(a)[I...] broken = arrayt ≢ Array
 
     a = BlockSparseArray{elt}(undef, [2, 3], [2, 3])
     @views for b in [Block(1, 1), Block(2, 2)]
@@ -718,5 +714,5 @@ arrayts = (Array, JLArray)
     a[Block(2, 2)] = randn(elt, 3, 3)
     @test a[2:4, 4] == Array(a)[2:4, 4]
     # TODO: Fix this.
-    @test_broken a[4, 2:4] == Array(a)[4, 2:4]
+    @test a[4, 2:4] == Array(a)[4, 2:4] broken = true
 end

--- a/test/test_tensoralgebraext.jl
+++ b/test/test_tensoralgebraext.jl
@@ -2,7 +2,7 @@ using BlockArrays: Block, BlockArray, blockedrange, blocksize
 using BlockSparseArrays: BlockSparseArray
 using Random: randn!
 using TensorAlgebra: contract
-using Test: @test, @test_broken, @testset
+using Test: @test, @testset
 
 function randn_blockdiagonal(elt::Type, axes::Tuple)
     a = BlockSparseArray{elt}(undef, axes)


### PR DESCRIPTION
## Summary

Two issues surface in `test/test_abstract_blocktype.jl` once MatrixAlgebraKit 0.6.6 is resolved (which can happen on any new `Pkg.add`/`Pkg.update` against the registered v0.10.39, since its `test/Project.toml` allows `MatrixAlgebraKit = "0.6.0 - 0.6.4, 0.6.6"`):

- `@test_broken f(a)` for `f ∈ (svd_full, svd_trunc)` on JLArray-backed `BlockSparseMatrix{T, AbstractMatrix{T}}` errors with `Expression evaluated to non-Boolean` because `svd_full` now succeeds and returns a 3-tuple — it used to throw, which `@test_broken` correctly caught.
- The unconditional `@test c * u ≈ a` in the right-side loop is flaky on JLArray for `right_orth`, `lq_compact`, `lq_full`. These factorizations regressed in MatrixAlgebraKit 0.6.5/0.6.6 and produce `c * u != a` on GPU-backed inputs (0.6.4 was correct), tracked upstream at QuantumKitHub/MatrixAlgebraKit.jl#218. Whether the assertion fails on a given CI run depends on the random matrix.

This PR:

- Seeds each `(arrayt, elt)` iteration with `StableRNG(1)` so the test is deterministic across runs.
- Promotes `svd_full` to a regular `@test` on JLArray (the math is now correct).
- Wraps `svd_trunc` in a Boolean-safe `@test ... broken = true` block so its return value can no longer surface as a non-Boolean error.
- Marks `c * u ≈ a` as broken on JLArray for `right_orth`, `lq_compact`, `lq_full`, with a comment pointing at QuantumKitHub/MatrixAlgebraKit.jl#218.

## Test plan

- [x] `Pkg.test BlockSparseArrays` passes locally with MatrixAlgebraKit 0.6.6 (`test_abstract_blocktype.jl`: 198 pass + 54 broken = 252).
- [ ] CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)